### PR TITLE
Fix: Update product creation to use product_type_id

### DIFF
--- a/app/Http/Requests/Admin/StoreProductRequest.php
+++ b/app/Http/Requests/Admin/StoreProductRequest.php
@@ -30,7 +30,10 @@ class StoreProductRequest extends FormRequest
             // o si se envía, debe ser único.
             'slug' => ['nullable', 'string', 'max:255', Rule::unique('products', 'slug')],
             'description' => ['nullable', 'string'],
-            'type' => ['required', 'string', Rule::in(['shared_hosting', 'vps', 'dedicated_server', 'domain_registration', 'ssl_certificate', 'other'])],
+            // Make 'type' nullable as it's being deprecated
+            'type' => ['nullable', 'string', Rule::in(['shared_hosting', 'vps', 'dedicated_server', 'domain_registration', 'ssl_certificate', 'other'])],
+            // Add rule for product_type_id
+            'product_type_id' => ['required', 'integer', 'exists:product_types,id'],
             'module_name' => ['nullable', 'string', 'max:255'],
             'owner_id' => ['nullable', 'integer', 'exists:users,id'],
             'status' => ['required', 'string', Rule::in(['active', 'inactive', 'hidden'])],

--- a/tests/Feature/Admin/ProductCreationTest.php
+++ b/tests/Feature/Admin/ProductCreationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Product;
+use App\Models\ProductType;
+
+class ProductCreationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_product_with_product_type_id(): void
+    {
+        // 1. Create and authenticate admin user
+        $adminUser = User::factory()->create(['role' => 'admin']); // Ensure User model has 'role' attribute or adjust
+        $this->actingAs($adminUser);
+
+        // 2. Create a ProductType
+        $productType = ProductType::factory()->create(['name' => 'Test Product Type Special']); // Use a unique name
+
+        // 3. Prepare product data
+        $productData = [
+            'name' => 'Test Product Awesome Unique', // Use a unique name
+            'description' => 'This is a test product.',
+            'product_type_id' => $productType->id,
+            // 'type' should not be sent, or StoreProductRequest should handle its absence if nullable
+            'status' => 'active',
+            'is_publicly_available' => true,
+            'is_resellable_by_default' => false,
+            // Ensure all other required fields from StoreProductRequest are included
+            // For example, if 'slug' is not auto-generated on null, it might be needed.
+            // Based on StoreProductRequest, 'slug' is nullable.
+            // 'type' is now nullable in StoreProductRequest.
+        ];
+
+        // 4. Make POST request
+        $response = $this->post(route('admin.products.store'), $productData);
+
+        // 5. Assert redirect and success message
+        $response->assertRedirect(route('admin.products.index'));
+        $response->assertSessionHas('success');
+
+        // 6. Assert product exists in database
+        $this->assertDatabaseHas('products', [
+            'name' => 'Test Product Awesome Unique',
+            'product_type_id' => $productType->id,
+            'status' => 'active',
+            'description' => 'This is a test product.',
+            'is_publicly_available' => true,
+            'is_resellable_by_default' => false,
+        ]);
+
+        // Optional: Assert that the old 'type' field is null for the created product if it still exists
+        $createdProduct = Product::where('name', 'Test Product Awesome Unique')->first();
+        $this->assertNotNull($createdProduct);
+        // If the 'type' column still exists and is part of $fillable,
+        // and was not part of $productData, its value would depend on DB default or model mutators.
+        // Given StoreProductRequest makes 'type' nullable, and controller unsets it if product_type_id is present,
+        // it should ideally be null or not set if not provided.
+        // $this->assertNull($createdProduct->type); // This assertion depends on the final state of 'type' column.
+    }
+}


### PR DESCRIPTION
This commit resolves an issue where product creation was failing due to a mismatch between frontend data submission and backend validation.

The `StoreProductRequest` was requiring an old 'type' (string) field, while the frontend was correctly sending 'product_type_id' (integer) as part of a transition to using a dedicated product_types table.

Changes:
- Modified `app/Http/Requests/Admin/StoreProductRequest.php`:
    - Changed the 'type' validation rule to be `nullable`.
    - Added a `required` validation rule for `product_type_id`, ensuring it's an integer and exists in the `product_types` table.
- Verified that `app/Http/Controllers/Admin/AdminProductController.php` correctly handles the new `product_type_id` and unsets the old `type` field if `product_type_id` is present. No changes were needed.
- Verified that the frontend component `resources/js/Pages/Admin/Products/Create.vue` already sends `product_type_id`. No changes were needed.
- Added a new feature test `tests/Feature/Admin/ProductCreationTest.php` to cover successful product creation with `product_type_id`, ensuring the fix works and preventing regressions.