### PR TITLE
Fix: Implement URL-based navigation for service categories on Landing…

### DIFF
--- a/resources/js/Pages/LandingPage.vue
+++ b/resources/js/Pages/LandingPage.vue
@@ -252,8 +252,7 @@ const selectedCategoryData = computed(() => {
     <div v-else-if="serviceData" class="flex flex-col min-h-screen bg-slate-900">
         <!-- Renderizar los componentes traducidos -->
         <Header :appName="serviceData.appName" :serviceCategories="serviceData.serviceCategories" :canLogin="canLogin"
-            :canRegister="canRegister" :auth="$page.props.auth" @contactClick="handleOpenModal()"
-            @navigate="handleNavigation" />
+            :canRegister="canRegister" :auth="$page.props.auth" @contactClick="handleOpenModal()" />
 
         <main ref="appMainRef" class="flex-grow overflow-y-auto">
             <div v-if="currentPage === 'landing'">
@@ -267,7 +266,7 @@ const selectedCategoryData = computed(() => {
                     :markupPercentage="serviceData.markupPercentage" :planButtonText="serviceData.planButtonText"
                     @planContact="handleOpenModal" />
                 <AllCategoriesList :title="serviceData.serviceCategoriesTitle"
-                    :categories="serviceData.serviceCategories" @navigate="handleNavigation" />
+                    :categories="serviceData.serviceCategories" />
             </div>
 
             <div v-else-if="currentPage === 'categoryDetail' && selectedCategoryData">
@@ -278,8 +277,7 @@ const selectedCategoryData = computed(() => {
         </main>
 
         <Footer :appName="serviceData.appName" :paymentMethods="serviceData.paymentMethods"
-            :contactInfo="serviceData.contactInfo" :serviceCategories="serviceData.serviceCategories"
-            @navigate="handleNavigation" />
+            :contactInfo="serviceData.contactInfo" :serviceCategories="serviceData.serviceCategories" />
 
         <ContactModal :isOpen="isModalOpen" :contactInfo="serviceData.contactInfo" :contactedPlan="contactedPlanName"
             @close="handleCloseModal" />


### PR DESCRIPTION
…Page

Previously, selecting a service category on the landing page did not update the URL. This meant you could not directly navigate to or refresh a specific category page.

This commit ensures that:
1. Laravel routes (`/` and `/servicios/{categorySlug}`) are correctly defined and handled by `LandingPageController` to pass an `activeCategorySlug` prop to the `LandingPage.vue` component.
2. Navigation elements within `Header.vue`, `AllCategoriesList.vue`, and `Footer.vue` utilize Inertia's `<Link>` component, pointing to the `landing.category` named route with the appropriate category slug.
3. `LandingPage.vue` uses a `watchEffect` to monitor the `activeCategorySlug` prop and dynamically display either the main landing content or the specific service category details.
4. Unused `@navigate` event listeners were removed from the `LandingPage.vue` template for code cleanliness.

With these changes, clicking a category link now updates the URL, allowing for direct navigation, sharing of links, and correct page state on refresh.