### PR TITLE
Fix: Prevent blank category pages due to missing planIcon

### DIFF
--- a/resources/js/Components/Landing/PlanCard.vue
+++ b/resources/js/Components/Landing/PlanCard.vue
@@ -92,7 +92,7 @@ const handleContact = () => {
         <div class="flex items-center mb-5">
             <Icon :name="categoryIcon" class="w-10 h-10 mr-3 text-brand-blue" />
             <h3 class="text-2xl font-semibold text-slate-800">{{ plan.name }}</h3>
-            <Icon :name="plan.planIcon" class="w-10 h-10 ml-3 text-brand-blue" />
+            <Icon v-if="plan.planIcon" :name="plan.planIcon" class="w-10 h-10 ml-3 text-brand-blue" />
         </div>
         <p class="text-slate-600 mb-2 text-sm min-h-[40px]">{{ plan.description }}</p>
 


### PR DESCRIPTION
Category detail pages were appearing blank if a plan within that category was missing the 'planIcon' property. This was likely due to the Icon component potentially erroring when its 'name' prop was undefined.

This commit modifies PlanCard.vue to conditionally render the plan-specific Icon only if 'plan.planIcon' is defined, by adding a v-if directive:

<Icon v-if="plan.planIcon" :name="plan.planIcon" ... />

This makes the rendering of plan cards more robust against missing optional data and should resolve the blank page issue.