### PR TITLE
Feature: Add Funds to Client Balance using PayPal

### DIFF
--- a/app/Http/Controllers/Client/ClientFundAdditionController.php
+++ b/app/Http/Controllers/Client/ClientFundAdditionController.php
@@ -10,9 +10,27 @@ use Illuminate\Http\Request; // Keep for potential future use, though not direct
 use Inertia\Inertia;
 use App\Http\Requests\Client\StoreFundAdditionRequest; // Will be created next
 use Illuminate\Support\Facades\Redirect;
+use App\Services\PayPalService;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log; // Added for logging in new methods
+use Illuminate\Support\Facades\DB; // Added for DB transactions in new methods
+// Inertia is already imported via `use Inertia\Inertia;`
+// PaymentMethod is already imported via `use App\Models\PaymentMethod;`
+// Auth is already imported via `use Illuminate\Support\Facades\Auth;`
+// Request is already imported via `use Illuminate\Http\Request;`
+
 
 class ClientFundAdditionController extends Controller
 {
+    protected PayPalService $payPalService;
+
+    public function __construct(PayPalService $payPalService)
+    {
+        $this->payPalService = $payPalService;
+    }
+
     /**
      * Show the form for adding funds.
      */
@@ -57,5 +75,145 @@ class ClientFundAdditionController extends Controller
 
         return Redirect::route('client.transactions.index') // Or client.dashboard if more appropriate
             ->with('success', 'Tu solicitud para agregar fondos ha sido enviada y está pendiente de confirmación.');
+    }
+
+    public function initiatePayPalPayment(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'amount' => 'required|numeric|min:0.01', // Validación básica del monto
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->route('client.funds.create')->withErrors($validator)->withInput();
+        }
+
+        $amount = (float) $request->input('amount');
+
+        // Validación de monto mínimo para PayPal
+        if ($amount < 30.00) { // Assuming a minimum like $5.00 USD, adjust as needed
+            return redirect()->route('client.funds.create')
+                ->with('error', 'Para agregar fondos con PayPal, el monto mínimo es de $30.00 USD.')
+                ->withInput();
+        }
+
+        $user = Auth::user();
+        $currencyCode = $user->currency_code ?? config('paypal.currency', 'USD'); // Usar moneda del usuario o default de PayPal
+
+        try {
+            $successUrl = route('client.funds.paypal.success');
+            $cancelUrl = route('client.funds.paypal.cancel');
+
+            $fundAdditionIdentifier = 'FUNDS-' . $user->id . '-' . strtoupper(Str::random(8));
+
+            $orderForPayPal = new \stdClass();
+            $orderForPayPal->id = $fundAdditionIdentifier;
+            $orderForPayPal->invoice_number = 'ADD-FUNDS-' . $user->id;
+            $orderForPayPal->total_amount = $amount;
+            $orderForPayPal->currency_code = $currencyCode;
+
+            $paypalOrderDetails = $this->payPalService->createOrder(
+                $orderForPayPal,
+                $successUrl,
+                $cancelUrl
+            );
+
+            if ($paypalOrderDetails && isset($paypalOrderDetails['approval_link'])) {
+                $request->session()->put('paypal_fund_order_id', $paypalOrderDetails['order_id']);
+                $request->session()->put('paypal_fund_amount', $amount);
+                $request->session()->put('paypal_fund_currency', $currencyCode);
+                $request->session()->put('paypal_fund_identifier', $fundAdditionIdentifier);
+
+                return Inertia::location($paypalOrderDetails['approval_link']);
+            } else {
+                Log::error('PayPal fund addition: Failed to get approval link.', ['user_id' => $user->id, 'amount' => $amount, 'paypal_response' => $paypalOrderDetails]);
+                return redirect()->route('client.funds.create')
+                    ->with('error', 'No se pudo iniciar el pago con PayPal. Por favor, intente más tarde.');
+            }
+        } catch (\Exception $e) {
+            Log::error('PayPal fund addition exception: ' . $e->getMessage(), [
+                'user_id' => $user->id, 'amount' => $amount, 'trace' => substr($e->getTraceAsString(), 0, 500)
+            ]);
+            return redirect()->route('client.funds.create')
+                ->with('error', 'Ocurrió un error inesperado con PayPal. Por favor, contacte a soporte.');
+        }
+    }
+
+    public function handlePayPalSuccess(Request $request)
+    {
+        $paypalOrderId = $request->session()->get('paypal_fund_order_id');
+        $amount = $request->session()->get('paypal_fund_amount');
+        $currencyCode = $request->session()->get('paypal_fund_currency');
+        // $fundIdentifier = $request->session()->get('paypal_fund_identifier');
+
+        if (!$paypalOrderId || !is_numeric($amount) || !$currencyCode) {
+            Log::error('PayPal fund success: Missing or invalid session data.', [
+                'session_data' => $request->session()->all(),
+                'user_id' => Auth::id()
+            ]);
+            return redirect()->route('client.funds.create')->with('error', 'Error al procesar el pago de PayPal: Sesión inválida o datos corruptos.');
+        }
+
+        $user = Auth::user();
+
+        try {
+            $captureResponse = $this->payPalService->captureOrder($paypalOrderId);
+
+            if ($captureResponse && isset($captureResponse['status']) && $captureResponse['status'] === 'COMPLETED') {
+                DB::beginTransaction();
+                try {
+                    $paypalPaymentMethod = PaymentMethod::where('slug', 'paypal')->first();
+
+                    Transaction::create([
+                        'client_id' => $user->id,
+                        'invoice_id' => null,
+                        'payment_method_id' => $paypalPaymentMethod ? $paypalPaymentMethod->id : null,
+                        'gateway_slug' => 'paypal',
+                        'gateway_transaction_id' => $captureResponse['paypal_capture_id'] ?? 'N/A',
+                        'type' => 'credit_added',
+                        'amount' => (float) $amount,
+                        'currency_code' => $currencyCode,
+                        'status' => 'completed',
+                        'description' => "Adición de fondos vía PayPal. ID de captura: " . ($captureResponse['paypal_capture_id'] ?? 'N/A'),
+                        'transaction_date' => Carbon::now(),
+                        'fees_amount' => $captureResponse['paypal_fee'] ?? 0.00,
+                    ]);
+
+                    $user->increment('balance', (float) $amount);
+                    // $user->save(); // increment already saves
+
+                    DB::commit();
+
+                    $request->session()->forget(['paypal_fund_order_id', 'paypal_fund_amount', 'paypal_fund_currency', 'paypal_fund_identifier']);
+                    return redirect()->route('client.dashboard')
+                        ->with('success', 'Fondos agregados exitosamente a tu cuenta por ' . $currencyCode . ' ' . number_format((float)$amount, 2) . '.');
+
+                } catch (\Exception $e) {
+                    DB::rollBack();
+                    Log::error('PayPal fund success - DB transaction error: ' . $e->getMessage(), [
+                        'user_id' => $user->id, 'paypal_order_id' => $paypalOrderId, 'trace' => substr($e->getTraceAsString(), 0, 500)
+                    ]);
+                    return redirect()->route('client.funds.create')->with('error', 'Error al registrar la adición de fondos después del pago. Contacte a soporte.');
+                }
+            } else {
+                Log::error('PayPal fund success - Capture failed or status not COMPLETED.', [
+                    'user_id' => $user->id, 'paypal_order_id' => $paypalOrderId, 'capture_response' => $captureResponse
+                ]);
+                $request->session()->forget(['paypal_fund_order_id', 'paypal_fund_amount', 'paypal_fund_currency', 'paypal_fund_identifier']);
+                return redirect()->route('client.funds.create')->with('error', 'Falló la captura del pago con PayPal. No se agregaron fondos.');
+            }
+        } catch (\Exception $e) {
+            Log::error('PayPal fund success - General exception: ' . $e->getMessage(), [
+                'user_id' => $user->id, 'paypal_order_id' => $paypalOrderId, 'trace' => substr($e->getTraceAsString(), 0, 500)
+            ]);
+            $request->session()->forget(['paypal_fund_order_id', 'paypal_fund_amount', 'paypal_fund_currency', 'paypal_fund_identifier']);
+            return redirect()->route('client.funds.create')->with('error', 'Error inesperado procesando el pago con PayPal. Contacte a soporte.');
+        }
+    }
+
+    public function handlePayPalCancel(Request $request)
+    {
+        $request->session()->forget(['paypal_fund_order_id', 'paypal_fund_amount', 'paypal_fund_currency', 'paypal_fund_identifier']);
+        Log::info('PayPal fund addition cancelled by user.', ['user_id' => Auth::id()]);
+        return redirect()->route('client.funds.create')->with('info', 'La adición de fondos con PayPal fue cancelada.');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -165,6 +165,16 @@ Route::prefix('client')->name('client.')->middleware(['auth', 'verified'])->grou
   Route::get('/add-funds', [ClientFundAdditionController::class, 'showAddFundsForm'])->name('funds.create');
   Route::post('/add-funds', [ClientFundAdditionController::class, 'processFundAddition'])->name('funds.store');
 
+  // Client Fund Addition with PayPal
+  Route::post('/funds/paypal/initiate', [ClientFundAdditionController::class, 'initiatePayPalPayment'])
+      ->name('funds.paypal.initiate');
+
+  Route::get('/funds/paypal/success', [ClientFundAdditionController::class, 'handlePayPalSuccess'])
+      ->name('funds.paypal.success');
+
+  Route::get('/funds/paypal/cancel', [ClientFundAdditionController::class, 'handlePayPalCancel'])
+      ->name('funds.paypal.cancel');
+
   // Rutas para el listado de productos para clientes (handled by ClientDashboardController)
   Route::get('/products', [ClientDashboardController::class, 'listProducts'])->name('products.index');
 


### PR DESCRIPTION
This commit introduces the functionality for clients to add funds to their account balance using PayPal.

Key changes include:

1.  **New Routes**:
    *   Added `client.funds.paypal.initiate` (POST),
        `client.funds.paypal.success` (GET), and
        `client.funds.paypal.cancel` (GET) routes to handle the
        PayPal fund addition flow.

2.  **`ClientFundAdditionController` Updates**:
    *   Injected `PayPalService`.
    *   New method `initiatePayPalPayment` to:
        *   Validate the amount (including a minimum of $30 for PayPal).
        *   Create a PayPal order via `PayPalService` (using a simulated
          order object with a unique 'FUNDS-' prefixed identifier).
        *   Store necessary details (PayPal order ID, amount, currency,
          custom identifier) in the session.
        *   Redirect to PayPal for payment authorization.
    *   New method `handlePayPalSuccess` to:
        *   Capture the PayPal payment via `PayPalService`.
        *   If successful, create a `Transaction` record (type: 'credit_added',
          no invoice_id, linked to PayPal payment method).
        *   Increment the client's `balance`.
        *   Clear session data and redirect with a success message.
    *   New method `handlePayPalCancel` to clear session and redirect.

3.  **`PaypalGatewayService` (`handleWebhook`) Updates**:
    *   Modified the `PAYMENT.CAPTURE.COMPLETED` event handler to
        differentiate between invoice payments and fund additions.
    *   It inspects the `custom_id` or `invoice_id` from PayPal's
        purchase unit.
    *   If the ID starts with 'FUNDS-', it processes it as a fund addition:
        *   Checks for existing 'credit_added' transaction by PayPal capture ID
          (for idempotency).
        *   Extracts User ID from the 'FUNDS-USERID-RANDOM' identifier.
        *   Creates a 'credit_added' transaction and increments user balance
          if not already processed.
    *   If the ID is for an invoice, it follows the existing invoice
        payment logic (updates invoice, creates payment transaction,
        calls `ServiceProvisioningService`).

4.  **Frontend View (`Client/Funds/AddForm.vue`)**:
    *   Added a "Pay with PayPal" button and associated logic.
    *   The form now allows you to input an amount and choose PayPal.
    *   The PayPal button initiates a POST request to the
        `client.funds.paypal.initiate` route.
    *   Includes basic frontend validation for the amount and display
        of PayPal-specific error messages.

5.  **`PayPalService@createOrder`**:
    *   No changes were made, as the `stdClass` object passed for fund
        additions sufficiently mimics an `Invoice` object for the method's
        current needs (duck typing). Considered a future refactor if needed.

This enhancement provides clients with a convenient automated method to add funds to their accounts.