### PR TITLE
sync: Añadir log para depurar datos compartidos en HandleInertiaRequests

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Inertia\Middleware;
+use Illuminate\Support\Facades\Log; // Added Log facade
 
 class HandleInertiaRequests extends Middleware
 {
@@ -29,6 +30,13 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        Log::debug('Data being shared by HandleInertiaRequests for URI: ' . $request->getRequestUri(), [
+            'user_id' => $request->user() ? $request->user()->id : null,
+            'user_role' => $request->user() ? $request->user()->role : null,
+            'user_data_full' => $request->user() ? $request->user()->toArray() : null, // Log completo del usuario temporalmente
+            'session_all' => $request->session()->all() // Para ver qué hay en la sesión, incluyendo flash
+        ]);
+
         return array_merge(parent::share($request), [ // Usar array_merge es una forma común
             'auth' => [
                 'user' => $request->user() ? [


### PR DESCRIPTION
Se realiza este commit para sincronizar el estado del código, incluyendo un log de depuración temporal en el método `share` de `app/Http/Middleware/HandleInertiaRequests.php`.

El objetivo es verificar los datos del usuario (`auth.user`) y los mensajes flash que se están compartiendo con Inertia cuando accedes a la ruta `/client/services`, para diagnosticar por qué el menú y los iconos de acción podrían no estar visibles.

Este log será eliminado una vez que el problema se resuelva.